### PR TITLE
Fixed marshalling of NaN, json marshalled as 'null'

### DIFF
--- a/float.go
+++ b/float.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 )
@@ -88,7 +89,7 @@ func (f *Float) UnmarshalText(text []byte) error {
 // MarshalJSON implements json.Marshaler.
 // It will encode null if this Float is null.
 func (f Float) MarshalJSON() ([]byte, error) {
-	if !f.Valid {
+	if !f.Valid || math.IsNaN(f.Float64) {
 		return []byte("null"), nil
 	}
 	return []byte(strconv.FormatFloat(f.Float64, 'f', -1, 64)), nil

--- a/float_test.go
+++ b/float_test.go
@@ -2,6 +2,7 @@ package null
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 )
 
@@ -98,6 +99,11 @@ func TestMarshalFloat(t *testing.T) {
 	// invalid values should be encoded as null
 	null := NewFloat(0, false)
 	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, "null", "null json marshal")
+
+	nan := NewFloat(math.NaN(), true)
+	data, err = json.Marshal(nan)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
 }


### PR DESCRIPTION
JSON does not support NaN, which are valid values of float64 in Go so NaN needs to be marshalled as null. 