### PR TITLE
Fix test

### DIFF
--- a/zero/bool_test.go
+++ b/zero/bool_test.go
@@ -173,7 +173,7 @@ func TestBoolScan(t *testing.T) {
 
 func assertBool(t *testing.T, b Bool, from string) {
 	if b.Bool != true {
-		t.Errorf("bad %s bool: %d ≠ %v\n", from, b.Bool, true)
+		t.Errorf("bad %s bool: %v ≠ %v\n", from, b.Bool, true)
 	}
 	if !b.Valid {
 		t.Error(from, "is invalid, but should be valid")


### PR DESCRIPTION
The tests no longer run:

	$ go test ./...
	zero/bool_test.go:176: Errorf format %d has arg b.Bool of wrong type bool

This is because go test now automatically runs go vet.