### PR TITLE
Implement BindUnmarshaler

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -77,9 +77,9 @@ func (b *Bool) UnmarshalText(text []byte) error {
 	case "", "null":
 		b.Valid = false
 		return nil
-	case "true":
+	case "true", "on", "On", "ON":
 		b.Bool = true
-	case "false":
+	case "false", "off", "Off", "OFF":
 		b.Bool = false
 	default:
 		b.Valid = false
@@ -87,6 +87,13 @@ func (b *Bool) UnmarshalText(text []byte) error {
 	}
 	b.Valid = true
 	return nil
+}
+
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (b *Bool) UnmarshalParam(src string) error {
+	return b.UnmarshalText([]byte(src))
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/float.go
+++ b/float.go
@@ -94,6 +94,13 @@ func (f *Float) UnmarshalText(text []byte) error {
 	return err
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (f *Float) UnmarshalParam(text string) error {
+	return f.UnmarshalText([]byte(text))
+}
+
 // MarshalJSON implements json.Marshaler.
 // It will encode null if this Float is null.
 func (f Float) MarshalJSON() ([]byte, error) {

--- a/int.go
+++ b/int.go
@@ -94,6 +94,13 @@ func (i *Int) UnmarshalText(text []byte) error {
 	return err
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (i *Int) UnmarshalParam(text string) error {
+	return i.UnmarshalText([]byte(text))
+}
+
 // MarshalJSON implements json.Marshaler.
 // It will encode null if this Int is null.
 func (i Int) MarshalJSON() ([]byte, error) {

--- a/string.go
+++ b/string.go
@@ -98,6 +98,13 @@ func (s *String) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (s *String) UnmarshalParam(text string) error {
+	return s.UnmarshalText([]byte(text))
+}
+
 // SetValid changes this String's value and also sets it to be non-null.
 func (s *String) SetValid(v string) {
 	s.String = v

--- a/time.go
+++ b/time.go
@@ -128,6 +128,13 @@ func (t *Time) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (t *Time) UnmarshalParam(text string) error {
+	return t.UnmarshalText([]byte(text))
+}
+
 // SetValid changes this Time's value and sets it to be non-null.
 func (t *Time) SetValid(v time.Time) {
 	t.Time = v

--- a/zero/bool.go
+++ b/zero/bool.go
@@ -71,9 +71,9 @@ func (b *Bool) UnmarshalText(text []byte) error {
 	case "", "null":
 		b.Valid = false
 		return nil
-	case "true":
+	case "true", "on", "On", "ON":
 		b.Bool = true
-	case "false":
+	case "false", "off", "Off", "OFF":
 		b.Bool = false
 	default:
 		b.Valid = false
@@ -81,6 +81,13 @@ func (b *Bool) UnmarshalText(text []byte) error {
 	}
 	b.Valid = b.Bool
 	return nil
+}
+
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (b *Bool) UnmarshalParam(src string) error {
+	return b.UnmarshalText([]byte(src))
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/zero/float.go
+++ b/zero/float.go
@@ -86,6 +86,13 @@ func (f *Float) UnmarshalText(text []byte) error {
 	return err
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (f *Float) UnmarshalParam(text string) error {
+	return f.UnmarshalText([]byte(text))
+}
+
 // MarshalJSON implements json.Marshaler.
 // It will encode null if this Float is null.
 func (f Float) MarshalJSON() ([]byte, error) {

--- a/zero/int.go
+++ b/zero/int.go
@@ -87,6 +87,13 @@ func (i *Int) UnmarshalText(text []byte) error {
 	return err
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (i *Int) UnmarshalParam(text string) error {
+	return i.UnmarshalText([]byte(text))
+}
+
 // MarshalJSON implements json.Marshaler.
 // It will encode 0 if this Int is null.
 func (i Int) MarshalJSON() ([]byte, error) {

--- a/zero/string.go
+++ b/zero/string.go
@@ -83,6 +83,13 @@ func (s *String) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (s *String) UnmarshalParam(text string) error {
+	return s.UnmarshalText([]byte(text))
+}
+
 // SetValid changes this String's value and also sets it to be non-null.
 func (s *String) SetValid(v string) {
 	s.String = v

--- a/zero/time.go
+++ b/zero/time.go
@@ -128,6 +128,13 @@ func (t *Time) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// UnmarshalParam implements github.com/labstack/echo.BindUnmarshaler to
+// unmarshal a value from a query or form parameters. It behaves like
+// UnmarshalText.
+func (t *Time) UnmarshalParam(text string) error {
+	return t.UnmarshalText([]byte(text))
+}
+
 // SetValid changes this Time's value and
 // sets it to be non-null.
 func (t *Time) SetValid(v time.Time) {


### PR DESCRIPTION
This adds the `UnmarshalParam()` function from the `BindUnmarshaler`
interface from echo:
https://github.com/labstack/echo/blob/60072188355b8972c738a041666bd4b05957c135/bind.go#L24

This is useful for unmarshaling form and query values, and since it's
(mostly) a proxy to `UnmarshalText()` I don't see any downsides in
adding it.
The only exception is the `Bool`; I had to add `on` and `off`. I could
add these just for `UnmarshalParam`, but it seemed useful to me to add
it to `UnmarshalText` as well.