### PR TITLE
Added Equal method to nulltypes.

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -132,3 +132,8 @@ func (b Bool) Ptr() *bool {
 func (b Bool) IsZero() bool {
 	return !b.Valid
 }
+
+// Equal returns true if both booleans have the same value or are both null.
+func (b Bool) Equal(other Bool) bool {
+	return b.Valid == other.Valid && (!b.Valid || b.Bool == other.Bool)
+}

--- a/bool_test.go
+++ b/bool_test.go
@@ -188,6 +188,32 @@ func TestBoolValueOrZero(t *testing.T) {
 	}
 }
 
+func TestBoolEqual(t *testing.T) {
+	b1 := NewBool(true, false)
+	b2 := NewBool(true, false)
+	assertBoolEqualIsTrue(t, b1, b2)
+
+	b1 = NewBool(true, false)
+	b2 = NewBool(false, false)
+	assertBoolEqualIsTrue(t, b1, b2)
+
+	b1 = NewBool(true, true)
+	b2 = NewBool(true, true)
+	assertBoolEqualIsTrue(t, b1, b2)
+
+	b1 = NewBool(true, true)
+	b2 = NewBool(true, false)
+	assertBoolEqualIsFalse(t, b1, b2)
+
+	b1 = NewBool(true, false)
+	b2 = NewBool(true, true)
+	assertBoolEqualIsFalse(t, b1, b2)
+
+	b1 = NewBool(true, true)
+	b2 = NewBool(false, true)
+	assertBoolEqualIsFalse(t, b1, b2)
+}
+
 func assertBool(t *testing.T, b Bool, from string) {
 	if b.Bool != true {
 		t.Errorf("bad %s bool: %v ≠ %v\n", from, b.Bool, true)
@@ -209,5 +235,19 @@ func assertFalseBool(t *testing.T, b Bool, from string) {
 func assertNullBool(t *testing.T, b Bool, from string) {
 	if b.Valid {
 		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertBoolEqualIsTrue(t *testing.T, a, b Bool) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of Bool{%t, Valid:%t} and Bool{%t, Valid:%t} should return true", a.Bool, a.Valid, b.Bool, b.Valid)
+	}
+}
+
+func assertBoolEqualIsFalse(t *testing.T, a, b Bool) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of Bool{%t, Valid:%t} and Bool{%t, Valid:%t} should return false", a.Bool, a.Valid, b.Bool, b.Valid)
 	}
 }

--- a/float.go
+++ b/float.go
@@ -137,3 +137,12 @@ func (f Float) Ptr() *float64 {
 func (f Float) IsZero() bool {
 	return !f.Valid
 }
+
+// Equal returns true if both floats have the same value or are both null.
+// Warning: calculations using floating point numbers can result in different ways
+// the numbers are stored in memory. Therefore, this function is not suitable to
+// compare the result of a calculation. Use this method only to check if the value
+// has changed in comparison to some previous value.
+func (f Float) Equal(other Float) bool {
+	return f.Valid == other.Valid && (!f.Valid || f.Float64 == other.Float64)
+}

--- a/float_test.go
+++ b/float_test.go
@@ -197,6 +197,32 @@ func TestFloatValueOrZero(t *testing.T) {
 	}
 }
 
+func TestFloatEqual(t *testing.T) {
+	f1 := NewFloat(10, false)
+	f2 := NewFloat(10, false)
+	assertFloatEqualIsTrue(t, f1, f2)
+
+	f1 = NewFloat(10, false)
+	f2 = NewFloat(20, false)
+	assertFloatEqualIsTrue(t, f1, f2)
+
+	f1 = NewFloat(10, true)
+	f2 = NewFloat(10, true)
+	assertFloatEqualIsTrue(t, f1, f2)
+
+	f1 = NewFloat(10, true)
+	f2 = NewFloat(10, false)
+	assertFloatEqualIsFalse(t, f1, f2)
+
+	f1 = NewFloat(10, false)
+	f2 = NewFloat(10, true)
+	assertFloatEqualIsFalse(t, f1, f2)
+
+	f1 = NewFloat(10, true)
+	f2 = NewFloat(20, true)
+	assertFloatEqualIsFalse(t, f1, f2)
+}
+
 func assertFloat(t *testing.T, f Float, from string) {
 	if f.Float64 != 1.2345 {
 		t.Errorf("bad %s float: %f ≠ %f\n", from, f.Float64, 1.2345)
@@ -209,5 +235,19 @@ func assertFloat(t *testing.T, f Float, from string) {
 func assertNullFloat(t *testing.T, f Float, from string) {
 	if f.Valid {
 		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertFloatEqualIsTrue(t *testing.T, a, b Float) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of Float{%v, Valid:%t} and Float{%v, Valid:%t} should return true", a.Float64, a.Valid, b.Float64, b.Valid)
+	}
+}
+
+func assertFloatEqualIsFalse(t *testing.T, a, b Float) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of Float{%v, Valid:%t} and Float{%v, Valid:%t} should return false", a.Float64, a.Valid, b.Float64, b.Valid)
 	}
 }

--- a/int.go
+++ b/int.go
@@ -131,3 +131,8 @@ func (i Int) Ptr() *int64 {
 func (i Int) IsZero() bool {
 	return !i.Valid
 }
+
+// Equal returns true if both ints have the same value or are both null.
+func (i Int) Equal(other Int) bool {
+	return i.Valid == other.Valid && (!i.Valid || i.Int64 == other.Int64)
+}

--- a/int_test.go
+++ b/int_test.go
@@ -203,6 +203,32 @@ func TestIntValueOrZero(t *testing.T) {
 	}
 }
 
+func TestIntEqual(t *testing.T) {
+	int1 := NewInt(10, false)
+	int2 := NewInt(10, false)
+	assertIntEqualIsTrue(t, int1, int2)
+
+	int1 = NewInt(10, false)
+	int2 = NewInt(20, false)
+	assertIntEqualIsTrue(t, int1, int2)
+
+	int1 = NewInt(10, true)
+	int2 = NewInt(10, true)
+	assertIntEqualIsTrue(t, int1, int2)
+
+	int1 = NewInt(10, true)
+	int2 = NewInt(10, false)
+	assertIntEqualIsFalse(t, int1, int2)
+
+	int1 = NewInt(10, false)
+	int2 = NewInt(10, true)
+	assertIntEqualIsFalse(t, int1, int2)
+
+	int1 = NewInt(10, true)
+	int2 = NewInt(20, true)
+	assertIntEqualIsFalse(t, int1, int2)
+}
+
 func assertInt(t *testing.T, i Int, from string) {
 	if i.Int64 != 12345 {
 		t.Errorf("bad %s int: %d ≠ %d\n", from, i.Int64, 12345)
@@ -215,5 +241,19 @@ func assertInt(t *testing.T, i Int, from string) {
 func assertNullInt(t *testing.T, i Int, from string) {
 	if i.Valid {
 		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertIntEqualIsTrue(t *testing.T, a, b Int) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of Int{%v, Valid:%t} and Int{%v, Valid:%t} should return true", a.Int64, a.Valid, b.Int64, b.Valid)
+	}
+}
+
+func assertIntEqualIsFalse(t *testing.T, a, b Int) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of Int{%v, Valid:%t} and Int{%v, Valid:%t} should return false", a.Int64, a.Valid, b.Int64, b.Valid)
 	}
 }

--- a/string.go
+++ b/string.go
@@ -116,3 +116,8 @@ func (s String) Ptr() *string {
 func (s String) IsZero() bool {
 	return !s.Valid
 }
+
+// Equal returns true if both strings have the same value or are both null.
+func (s String) Equal(other String) bool {
+	return s.Valid == other.Valid && (!s.Valid || s.String == other.String)
+}

--- a/string_test.go
+++ b/string_test.go
@@ -190,6 +190,32 @@ func TestStringValueOrZero(t *testing.T) {
 	}
 }
 
+func TestStringEqual(t *testing.T) {
+	str1 := NewString("foo", false)
+	str2 := NewString("foo", false)
+	assertStringEqualIsTrue(t, str1, str2)
+
+	str1 = NewString("foo", false)
+	str2 = NewString("bar", false)
+	assertStringEqualIsTrue(t, str1, str2)
+
+	str1 = NewString("foo", true)
+	str2 = NewString("foo", true)
+	assertStringEqualIsTrue(t, str1, str2)
+
+	str1 = NewString("foo", true)
+	str2 = NewString("foo", false)
+	assertStringEqualIsFalse(t, str1, str2)
+
+	str1 = NewString("foo", false)
+	str2 = NewString("foo", true)
+	assertStringEqualIsFalse(t, str1, str2)
+
+	str1 = NewString("foo", true)
+	str2 = NewString("bar", true)
+	assertStringEqualIsFalse(t, str1, str2)
+}
+
 func maybePanic(err error) {
 	if err != nil {
 		panic(err)
@@ -214,5 +240,19 @@ func assertNullStr(t *testing.T, s String, from string) {
 func assertJSONEquals(t *testing.T, data []byte, cmp string, from string) {
 	if string(data) != cmp {
 		t.Errorf("bad %s data: %s ≠ %s\n", from, data, cmp)
+	}
+}
+
+func assertStringEqualIsTrue(t *testing.T, a, b String) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of String{\"%v\", Valid:%t} and String{\"%v\", Valid:%t} should return true", a.String, a.Valid, b.String, b.Valid)
+	}
+}
+
+func assertStringEqualIsFalse(t *testing.T, a, b String) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of String{\"%v\", Valid:%t} and String{\"%v\", Valid:%t} should return false", a.String, a.Valid, b.String, b.Valid)
 	}
 }

--- a/time.go
+++ b/time.go
@@ -147,3 +147,17 @@ func (t Time) Ptr() *time.Time {
 func (t Time) IsZero() bool {
 	return !t.Valid
 }
+
+// Equal returns true if both Time objects encode the same time or are both null.
+// Two times can be equal even if they are in different locations.
+// For example, 6:00 +0200 CEST and 4:00 UTC are Equal.
+func (t Time) Equal(other Time) bool {
+	return t.Valid == other.Valid && (!t.Valid || t.Time.Equal(other.Time))
+}
+
+// ExactEqual returns true if both Time objects are equal or both null.
+// ExactEqual returns false for times that are in different locations or
+// have a different monotonic clock reading.
+func (t Time) ExactEqual(other Time) bool {
+	return t.Valid == other.Valid && (!t.Valid || t.Time == other.Time)
+}

--- a/time_test.go
+++ b/time_test.go
@@ -7,13 +7,17 @@ import (
 )
 
 var (
-	timeString   = "2012-12-21T21:21:21Z"
-	timeJSON     = []byte(`"` + timeString + `"`)
-	nullTimeJSON = []byte(`null`)
-	timeValue, _ = time.Parse(time.RFC3339, timeString)
-	timeObject   = []byte(`{"Time":"2012-12-21T21:21:21Z","Valid":true}`)
-	nullObject   = []byte(`{"Time":"0001-01-01T00:00:00Z","Valid":false}`)
-	badObject    = []byte(`{"hello": "world"}`)
+	timeString1   = "2012-12-21T21:21:21Z"
+	timeString2   = "2012-12-21T22:21:21+01:00" // Same time as timeString1 but in a different timezone
+	timeString3   = "2018-08-19T01:02:03Z"
+	timeJSON      = []byte(`"` + timeString1 + `"`)
+	nullTimeJSON  = []byte(`null`)
+	timeValue1, _ = time.Parse(time.RFC3339, timeString1)
+	timeValue2, _ = time.Parse(time.RFC3339, timeString2)
+	timeValue3, _ = time.Parse(time.RFC3339, timeString3)
+	timeObject    = []byte(`{"Time":"2012-12-21T21:21:21Z","Valid":true}`)
+	nullObject    = []byte(`{"Time":"0001-01-01T00:00:00Z","Valid":false}`)
+	badObject     = []byte(`{"hello": "world"}`)
 )
 
 func TestUnmarshalTimeJSON(t *testing.T) {
@@ -60,10 +64,10 @@ func TestUnmarshalTimeJSON(t *testing.T) {
 }
 
 func TestUnmarshalTimeText(t *testing.T) {
-	ti := TimeFrom(timeValue)
+	ti := TimeFrom(timeValue1)
 	txt, err := ti.MarshalText()
 	maybePanic(err)
-	assertJSONEquals(t, txt, timeString, "marshal text")
+	assertJSONEquals(t, txt, timeString1, "marshal text")
 
 	var unmarshal Time
 	err = unmarshal.UnmarshalText(txt)
@@ -87,7 +91,7 @@ func TestUnmarshalTimeText(t *testing.T) {
 }
 
 func TestMarshalTime(t *testing.T) {
-	ti := TimeFrom(timeValue)
+	ti := TimeFrom(timeValue1)
 	data, err := json.Marshal(ti)
 	maybePanic(err)
 	assertJSONEquals(t, data, string(timeJSON), "non-empty json marshal")
@@ -99,12 +103,12 @@ func TestMarshalTime(t *testing.T) {
 }
 
 func TestTimeFrom(t *testing.T) {
-	ti := TimeFrom(timeValue)
+	ti := TimeFrom(timeValue1)
 	assertTime(t, ti, "TimeFrom() time.Time")
 }
 
 func TestTimeFromPtr(t *testing.T) {
-	ti := TimeFromPtr(&timeValue)
+	ti := TimeFromPtr(&timeValue1)
 	assertTime(t, ti, "TimeFromPtr() time")
 
 	null := TimeFromPtr(nil)
@@ -115,15 +119,15 @@ func TestTimeSetValid(t *testing.T) {
 	var ti time.Time
 	change := NewTime(ti, false)
 	assertNullTime(t, change, "SetValid()")
-	change.SetValid(timeValue)
+	change.SetValid(timeValue1)
 	assertTime(t, change, "SetValid()")
 }
 
 func TestTimePointer(t *testing.T) {
-	ti := TimeFrom(timeValue)
+	ti := TimeFrom(timeValue1)
 	ptr := ti.Ptr()
-	if *ptr != timeValue {
-		t.Errorf("bad %s time: %#v ≠ %v\n", "pointer", ptr, timeValue)
+	if *ptr != timeValue1 {
+		t.Errorf("bad %s time: %#v ≠ %v\n", "pointer", ptr, timeValue1)
 	}
 
 	var nt time.Time
@@ -136,10 +140,10 @@ func TestTimePointer(t *testing.T) {
 
 func TestTimeScanValue(t *testing.T) {
 	var ti Time
-	err := ti.Scan(timeValue)
+	err := ti.Scan(timeValue1)
 	maybePanic(err)
 	assertTime(t, ti, "scanned time")
-	if v, err := ti.Value(); v != timeValue || err != nil {
+	if v, err := ti.Value(); v != timeValue1 || err != nil {
 		t.Error("bad value or err:", v, err)
 	}
 
@@ -160,7 +164,7 @@ func TestTimeScanValue(t *testing.T) {
 }
 
 func TestTimeValueOrZero(t *testing.T) {
-	valid := TimeFrom(timeValue)
+	valid := TimeFrom(timeValue1)
 	if valid.ValueOrZero() != valid.Time || valid.ValueOrZero().IsZero() {
 		t.Error("unexpected ValueOrZero", valid.ValueOrZero())
 	}
@@ -173,7 +177,7 @@ func TestTimeValueOrZero(t *testing.T) {
 }
 
 func TestTimeIsZero(t *testing.T) {
-	str := TimeFrom(timeValue)
+	str := TimeFrom(timeValue1)
 	if str.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
@@ -189,9 +193,69 @@ func TestTimeIsZero(t *testing.T) {
 	}
 }
 
+func TestTimeEqual(t *testing.T) {
+	t1 := NewTime(timeValue1, false)
+	t2 := NewTime(timeValue2, false)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue3, false)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue2, true)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue1, true)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue2, false)
+	assertTimeEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue2, true)
+	assertTimeEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue3, true)
+	assertTimeEqualIsFalse(t, t1, t2)
+}
+
+func TestTimeExactEqual(t *testing.T) {
+	t1 := NewTime(timeValue1, false)
+	t2 := NewTime(timeValue1, false)
+	assertTimeExactEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue2, false)
+	assertTimeExactEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue1, true)
+	assertTimeExactEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue1, false)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue1, true)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue2, true)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue3, true)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+}
+
 func assertTime(t *testing.T, ti Time, from string) {
-	if ti.Time != timeValue {
-		t.Errorf("bad %v time: %v ≠ %v\n", from, ti.Time, timeValue)
+	if ti.Time != timeValue1 {
+		t.Errorf("bad %v time: %v ≠ %v\n", from, ti.Time, timeValue1)
 	}
 	if !ti.Valid {
 		t.Error(from, "is invalid, but should be valid")
@@ -201,5 +265,33 @@ func assertTime(t *testing.T, ti Time, from string) {
 func assertNullTime(t *testing.T, ti Time, from string) {
 	if ti.Valid {
 		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertTimeEqualIsTrue(t *testing.T, a, b Time) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return true", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}
+
+func assertTimeEqualIsFalse(t *testing.T, a, b Time) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return false", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}
+
+func assertTimeExactEqualIsTrue(t *testing.T, a, b Time) {
+	t.Helper()
+	if !a.ExactEqual(b) {
+		t.Errorf("ExactEqual() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return true", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}
+
+func assertTimeExactEqualIsFalse(t *testing.T, a, b Time) {
+	t.Helper()
+	if a.ExactEqual(b) {
+		t.Errorf("ExactEqual() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return false", a.Time, a.Valid, b.Time, b.Valid)
 	}
 }


### PR DESCRIPTION
I added the methods as discussed in #35 . The methods are called Equal instead of Equals (with -s) to be more consistent with the go library.

Interesting bits:
- Time can be compared using Equal (uses time.Time.Equals) and ExactEqual (uses the ==-operator)
- Equal is implemented for Float. The doc above the method mentions that comparing floats is not always recommended.