### PR TITLE
add encoder for Int type

### DIFF
--- a/int.go
+++ b/int.go
@@ -25,6 +25,12 @@ func NewInt(i int64, valid bool) Int {
 	}
 }
 
+// Encoder fulfills the requirements for encoding a null.Int for schema.RegisterEncoder
+func Encoder(val reflect.Value) string {
+	convVal := val.Interface().(Int)
+	return strconv.Itoa(int(convVal.ValueOrZero()))
+}
+
 // IntFrom creates a new Int that will always be valid.
 func IntFrom(i int64) Int {
 	return NewInt(i, true)


### PR DESCRIPTION
Adds an encoder type for use with https://github.com/gorilla/schema/blob/master/encoder.go#L33 

This is intended to resolve issues with passing Int values between services