### PR TITLE
[bug/fix-newstring-empty] fix empty string bug in StringFrom method

### DIFF
--- a/string.go
+++ b/string.go
@@ -22,7 +22,7 @@ type String struct {
 
 // StringFrom creates a new String that will never be blank.
 func StringFrom(s string) String {
-	return NewString(s, true)
+	return NewString(s, s != "")
 }
 
 // StringFromPtr creates a new String that be null if s is nil.

--- a/string_test.go
+++ b/string_test.go
@@ -24,8 +24,8 @@ func TestStringFrom(t *testing.T) {
 	assertStr(t, str, "StringFrom() string")
 
 	zero := StringFrom("")
-	if !zero.Valid {
-		t.Error("StringFrom(0)", "is invalid, but should be valid")
+	if zero.Valid {
+		t.Error("StringFrom(\"\")", "is valid, but should be invalid")
 	}
 }
 


### PR DESCRIPTION
`String.StringFrom("")` returns a valid sql.NullString.
this is a small fix to check on empty string